### PR TITLE
Package module needs "become: yes"

### DIFF
--- a/ansible/must-gather-singleton-playbook.yml
+++ b/ansible/must-gather-singleton-playbook.yml
@@ -1,7 +1,6 @@
 ---
 - name: Run Podman must-gather-singleton
   hosts: localhost
-  become: yes
   vars:
     # Define your containers with their unique properties
     containers:
@@ -18,13 +17,15 @@
       # Add more container configurations as needed
   tasks:
     - name: Ensure podman is installed
-      package:
+      ansible.builtin.package:
         name: podman
         state: present
+      become: yes
     - name: Start Podman must-gather-singleton container(s)
       containers.podman.podman_container:
         name: "{{ item.name }}"
         image: "{{ item.image }}"
+        #rm: true #Do this when done debugging,default is false
         state: started
         volumes:
           - "{{ item.volume_src }}:{{ item.container_dest }}"


### PR DESCRIPTION
Expanded package name to 'long name'
added "rm: true" to the podman module but left it commented out. 