### PR TITLE
Update 0426 - Containerfile update

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Use a base image
-FROM registry.access.redhat.com/ubi8
+FROM registry.access.redhat.com/ubi8-minimal
 
 ARG TITLE="must-gather-singleton"
 ARG DESCRIPTION="Collecting entire cluster stack data in a compact aggregated must-gather file"
@@ -10,8 +10,8 @@ ARG SOURCE="https://github.com/midu16/must-gather-singleton/Containerfile"
 
 COPY scripts/* /opt/
 
-RUN dnf update -y; dnf upgrade -y; dnf -y install python3; dnf clean all; pip3 install -r /opt/requirements.txt ; mkdir -p /apps/must-gather ;
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.14.10/openshift-client-linux-4.14.10.tar.gz | tar -xz -C /bin/
+#RUN microdnf update -y; microdnf upgrade -y; 
+RUN microdnf -y install python3 tar gzip; microdnf clean all; pip3 install -r /opt/requirements.txt ; mkdir -p /apps/must-gather ; curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.14.10/openshift-client-linux-4.14.10.tar.gz | tar -xz -C /bin/
 
 # Set environment variable
 ENV KUBECONFIG=/apps/kubeconfig


### PR DESCRIPTION
Switched from using ubi8/ubi to ubi8/ubi-minimal.
This reduced the container image size from 431Mb to 444Mb. 
Needed to update the dnf command to microdnf and add tar and gzip package installation. 
Rolled the curl/tar command into the single RUN statement
Removed the update/upgrade call as this is already calling the latest ubi8 image and 
any needed package upgrades will happen with the microdnf install of python3