### PR TITLE
Updates to Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -7,16 +7,17 @@ ARG AUTHORS="midu@redhat.com"
 ARG LICENSE="Apache-2.0"
 ARG URL="https://github.com/midu16/must-gather-singleton"
 ARG SOURCE="https://github.com/midu16/must-gather-singleton/Containerfile"
+ARG OCP_VERSION="stable-4.14"
 
 COPY scripts/* /opt/
+ENV OCP_VERSION=${OCP_VERSION:-stable-4.13}
+RUN echo "OCP VERSION: ${OCP_VERSION}"
 
-#RUN microdnf update -y; microdnf upgrade -y; 
-RUN microdnf -y install python3 tar gzip; microdnf clean all; pip3 install -r /opt/requirements.txt ; mkdir -p /apps/must-gather ; curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.14.10/openshift-client-linux-4.14.10.tar.gz | tar -xz -C /bin/
+#Install needed software and make needed directory. 
+RUN microdnf -y install python3 tar gzip; microdnf clean all; pip3 install -r /opt/requirements.txt ; mkdir -p /apps/must-gather ; curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OCP_VERSION}/openshift-client-linux.tar.gz | tar -xz -C /bin/
 
 # Set environment variable
 ENV KUBECONFIG=/apps/kubeconfig
-
-# Create a directory in the container
 
 # Mount volume from operating system to /apps/must-gather directory inside the container
 VOLUME /apps/must-gather

--- a/README.md
+++ b/README.md
@@ -17,7 +17,17 @@ The Containerfile ensures the following prerequisites installed and configured:
 ## Container Build Instructions
 
 > [!NOTE]  
-> podman build .
+> podman build --build-arg OCP_VERSION=stable-4.14 .
+
+Valid values for OCP_VERSION are any listed [HERE](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/).
+
+## Local Container Run Instructions
+
+> podman run --rm -it --name must-gather-singleton-spoke-1 -e KUBECONFIG=/apps/must-gather/kubeconfig -v /tmp/apps/must-gather-singleton/spoke-1/:/apps/must-gather/:z --pid=host --ipc=host IMAGE_ID
+
+## Prebuilt Container Run Instructions
+
+> podman run --rm -it --name must-gather-singleton-spoke-1 -e KUBECONFIG=/apps/must-gather/kubeconfig -v /tmp/apps/must-gather-singleton/spoke-1/:/apps/must-gather/:z --pid=host --ipc=host quay.io/midu/must-gather-singleton.x86_64:latest
 
 ## Functionality
 The script performs the following tasks:
@@ -25,6 +35,8 @@ The script performs the following tasks:
 - `Search for CSVs`: It searches for Cluster Service Versions (CSVs) in the Kubernetes or OpenShift cluster.
 
 - `Must-Gather`: It generates a must-gather command based on the related images found and executes it.
+
+- Bundle Output: It compresses the must-gather outputs into a tgz file in the mapped volume 
 
 
 ## Operators 

--- a/scripts/must-gather-singleton.py
+++ b/scripts/must-gather-singleton.py
@@ -290,8 +290,8 @@ def main():
       print("Kubeconfig not found")
       sys.exit(-1)
 
-    current_path = validate_directory_path()
-    if current_path == None:
+    output_path = validate_directory_path()
+    if output_path == None:
         print("Output directory path not found.")
         sys.exit(-1)
 
@@ -334,7 +334,7 @@ def main():
         invoke_must_gather(output_list, bundle_must_gather)
     directory_path, filename = os.path.split(newest_file_in_current_path())
 
-    create_tar(f'{directory_path}/{filename}', f'{current_path}/{filename}.tar.gz')
+    create_tar(f'{directory_path}/{filename}', f'{output_path}/{filename}.tar.gz')
     
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Updated Containerfile to support multiple versions of OCP. stable-4.14 is default
- Updated README.md with pointers to build and use the container image.
- Changed output path variable to output_path. It was confusing to use current_path in different ways in the newest_file_in_current_path function and current_path as the output destination. 