### PR TITLE
Update for variable kubeconfig

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,11 +10,10 @@ ARG SOURCE="https://github.com/midu16/must-gather-singleton/Containerfile"
 
 COPY scripts/* /opt/
 
-#RUN microdnf update -y; microdnf upgrade -y; 
-RUN microdnf -y install python3 tar gzip; microdnf clean all; pip3 install -r /opt/requirements.txt ; mkdir -p /apps/must-gather ; curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.14.10/openshift-client-linux-4.14.10.tar.gz | tar -xz -C /bin/
+RUN microdnf -y install python3 tar gzip vi; microdnf clean all; pip3 install -r /opt/requirements.txt ; mkdir -p /apps/must-gather ; curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.14.10/openshift-client-linux-4.14.10.tar.gz | tar -xz -C /bin/
 
 # Set environment variable
-ENV KUBECONFIG=/apps/kubeconfig
+#ENV KUBECONFIG=/apps/kubeconfig
 
 # Create a directory in the container
 
@@ -22,4 +21,5 @@ ENV KUBECONFIG=/apps/kubeconfig
 VOLUME /apps/must-gather
 
 # Specify the command to run when the container starts
-CMD  ["/usr/bin/python3", "/opt/must-gather-singleton.py"]
+#CMD  ["/usr/bin/python3", "/opt/must-gather-singleton.py"]
+CMD  ["/opt/must-gather-singleton.py"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ The Containerfile ensures the following prerequisites installed and configured:
 > [!NOTE]  
 > podman build .
 
+## Run the container
+
+Data inputs needed:
+
+- Host directory for collected directory output. This will be mapped to /apps/must-gather in the container
+- Kubeconfig file to access target cluster. This will be mapped to /root/.kube/config in the container
+
+
+> podman run --rm -it --name must-gather-singleton-x -v /path/to/target/kubeconfig:/root/.kube/config:z -v /tmp/apps/must-gather-singleton/spoke-1/:/apps/must-gather/:z --pid=host --ipc=host quay.io/namespace/must-gather:version
+
 ## Functionality
 The script performs the following tasks:
 

--- a/scripts/must-gather-singleton.py
+++ b/scripts/must-gather-singleton.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from kubernetes import client, config
 import openshift_client as oc
@@ -10,20 +10,41 @@ import re
 
 def checkKubeConfig():
     """
-    Gets the value of KUBECONFIG from the environment and test
-    to see if the file is accessible
+    Checks to see if the kubeconfig file is available.
+    The KUBECONFIG environment variable is checked then
+    ~/.kube/confg
+    KUBECONFIG overrides the default path
     Retruns True if found
+
+    From the kubectl docs:
+    By default, kubectl looks for a file named config in the
+    $HOME/.kube directory. You can specify other kubeconfig files
+    by setting the KUBECONFIG environment variable or by setting
+    the --kubeconfig flag.
 
     Parameters:
         none
     """
     retval = False
+    config_file = ""
 
-    if os.path.isfile( os.environ["KUBECONFIG"]):
-      #print("Kubeconfig is a file")
-      retval = True
+    try:
+        if os.path.isfile( os.environ["KUBECONFIG"]):
+          print("Kubeconfig is a file")
+          config_file = os.environ["KUBECONFIG"]
+          retval = True
+        #this parameter pointing at an invalide file wins over a valid default file
+        elif os.environ["KUBECONFIG"]:
+          print("KUBECONFIG defined but not pointing a file")
+          retval = False
+    except KeyError:
+        print("KUBECONFIG key not found")
+        if os.path.isfile("/root/.kube/config"):
+          print("Default file found")
+          config_file = "/root/.kube/config"
+          retval = True
 
-    return retval
+    return retval, config_file
 
 
 def get_csv_related_images_with_keyword(keyword):
@@ -77,13 +98,13 @@ def get_csv_related_images_with_keyword(keyword):
         return []
 
 
-def get_cluster_name():
+def get_cluster_name(config_file = ""):
     cluster_name = ""
     retval = True
 
     try:
         # Load Kubernetes configuration
-        config.load_kube_config()
+        config.load_kube_config(config_file=config_file)
 
         # Create an instance of the Kubernetes API client
         kube_client = client.CoreV1Api()
@@ -102,7 +123,6 @@ def get_cluster_name():
         retval = False
 
     return retval, cluster_name
-
 
 def newest_file_in_current_path():
     """
@@ -136,7 +156,6 @@ def create_tar(directory_path, tarfile_name):
     except Exception as e:
         print(f"Error occurred while creating tar file: {e}")
 
-
 def operator_info(input_string):
     """
     Parse the input string to extract operator name and version.
@@ -162,7 +181,6 @@ def operator_info(input_string):
         return {'operator_name': operator_name, 'operator_version': operator_version}
     else:
         return None
-
 
 def get_must_gather_url(operator_info):
     """
@@ -229,7 +247,6 @@ def get_must_gather_url(operator_info):
 
     return url
 
-
 def validate_directory_path():
     """
     Validating that the provided directory path exists.
@@ -249,7 +266,6 @@ def validate_directory_path():
     else:
         print(f"Error: The provided path '{directory_path}' does not exist.")
         return None
-
 
 def invoke_must_gather(output_list, bundle_must_gather):
     """
@@ -277,7 +293,6 @@ def invoke_must_gather(output_list, bundle_must_gather):
                           set(output_list),
                           set(bundle_must_gather)])
 
-
 def main():
     keyword = ["must-gather", "cluster-logging-operator", "must_gather_image", "mustgather", "must_gather"]
     # Initialize the
@@ -286,7 +301,8 @@ def main():
     mirror_must_gather = []
     output_list = []
 
-    if not checkKubeConfig():
+    retval, config_file = checkKubeConfig()
+    if not retval:
       print("Kubeconfig not found")
       sys.exit(-1)
 
@@ -295,7 +311,7 @@ def main():
         print("Output directory path not found.")
         sys.exit(-1)
 
-    retval, cluster_name = get_cluster_name()
+    retval, cluster_name = get_cluster_name(config_file = config_file)
     if not retval:
         print("Could not find cluster name: %s" %(cluster_name))
         sys.exit(-1)


### PR DESCRIPTION
Containerfile:
- remove KUBECONFIG env variable
- updated CMD with updated script permissions
- added vi to list of installed packages for development need. (this can be removed when dev efforts slow)
must-gather-singleton.py
- Updated #! line to use python3
- Set script to executable
must-gather-singleton.py::checkKubeConfig()
- Added support for passed in KUBECONFIG env (useful for CLI execution)
- Added checks for bad KUBECONFING
- Added support for default kube config mapped from the host OS
- Return found file
must-gather-singleton.py::get_cluster_name()
- Updated get_cluster_name to support passed in kube conf from checkKubeConfig()
Readme.md
- updated to include documentation on how to run the container and map in the host OS kube config file. 