### PR TITLE
Roll back change to Containerfile and update Readme.md

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -23,5 +23,4 @@ RUN microdnf -y install python3 tar gzip vi; microdnf clean all; pip3 install -r
 VOLUME /apps/must-gather
 
 # Specify the command to run when the container starts
-#CMD  ["/usr/bin/python3", "/opt/must-gather-singleton.py"]
-CMD  ["/opt/must-gather-singleton.py"]
+CMD  ["/usr/bin/python3", "/opt/must-gather-singleton.py"]

--- a/README.md
+++ b/README.md
@@ -19,15 +19,14 @@ The Containerfile ensures the following prerequisites installed and configured:
 > [!NOTE]  
 > podman build --build-arg OCP_VERSION=stable-4.14 .
 
-Valid values for OCP_VERSION are any listed [HERE](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/).
+Valid values for OCP_VERSION are any listed below:
 
-## Local Container Run Instructions
-
-> podman run --rm -it --name must-gather-singleton-spoke-1 -e KUBECONFIG=/apps/must-gather/kubeconfig -v /tmp/apps/must-gather-singleton/spoke-1/:/apps/must-gather/:z --pid=host --ipc=host IMAGE_ID
-
-## Prebuilt Container Run Instructions
-
-> podman run --rm -it --name must-gather-singleton-spoke-1 -e KUBECONFIG=/apps/must-gather/kubeconfig -v /tmp/apps/must-gather-singleton/spoke-1/:/apps/must-gather/:z --pid=host --ipc=host quay.io/midu/must-gather-singleton.x86_64:latest
+Supported OCP versions:
+- 4.16
+- 4.15
+- 4.14
+- 4.13
+- 4.12
 
 ## Run the container
 
@@ -36,8 +35,26 @@ Data inputs needed:
 - Host directory for collected directory output. This will be mapped to /apps/must-gather in the container
 - Kubeconfig file to access target cluster. This will be mapped to /root/.kube/config in the container
 
+Data outputs:
+- The compressed must gather data is written to the mapped host directory. 
 
-> podman run --rm -it --name must-gather-singleton-x -v /path/to/target/kubeconfig:/root/.kube/config:z -v /tmp/apps/must-gather-singleton/spoke-1/:/apps/must-gather/:z --pid=host --ipc=host quay.io/namespace/must-gather:version
+To run the container and wait for completion
+
+> podman run --rm -d --name must-gather-singleton-x -v /path/to/target/kubeconfig:/root/.kube/config:z -v /tmp/apps/must-gather-singleton/spoke-1/:/apps/must-gather/:z quay.io/namespace/must-gather:VERSION
+
+To run the container and return to the command line
+
+> podman run --rm -d --name must-gather-singleton-x -v /path/to/target/kubeconfig:/root/.kube/config:z -v /tmp/apps/must-gather-singleton/spoke-1/:/apps/must-gather/:z quay.io/namespace/must-gather:VERSION
+
+The progress can be monitored with the podman logs command
+
+> podman logs -f must-gather-singleton-x
+
+To run the container based must gather script interactivly:
+
+> podman run --rm -d -it --name must-gather-singleton-x -v /path/to/target/kubeconfig:/root/.kube/config:z -v /tmp/apps/must-gather-singleton/spoke-1/:/apps/must-gather/:z quay.io/namespace/must-gather:VERSION /bin/bash
+> [root@xxxyyy /] # /opt/must-gather-singleton.py
+
 
 ## Functionality
 The script performs the following tasks:

--- a/scripts/must-gather-singleton.py
+++ b/scripts/must-gather-singleton.py
@@ -326,7 +326,7 @@ def main():
             print("No CSVs were found with a matching must gather image keyword %s" %(index))
             continue
 
-        print(f"CSVs with related images containing keyword '{index}':")
+        print(f"Found CSVs with related images containing keyword '{index}'.")
         for csv in matching_csvs:
             # print(f"\nCSV Name: {csv['csv_name']}")
             operator = operator_info(csv['csv_name'])


### PR DESCRIPTION
Rolled back a change to the CMD line in the Containerfile. A script can be called directly as the #! is not interpreted. 
'/usr/bin/python3 /script.py' works. '/bin/env python3 /script.py' works too. 

Updated Readme.md 
- Supported OCP versions
- Data inputs and outputs
- Example container usage

Updated must-gather-singleton.py
- Minor readability improvement. 